### PR TITLE
LIBWEB-6391. Support for a new footer Legal menu.

### DIFF
--- a/components/umd-libraries-footer/umd-libraries-footer.component.yml
+++ b/components/umd-libraries-footer/umd-libraries-footer.component.yml
@@ -24,6 +24,9 @@ slots:
   navigation_menu_slot:
     title: Footer Menu Slot (Footer menu block)
     description: Slot intended for footer navigation menu. Each menu item should be placed in separate components.
+  legal_menu_slot:
+    title: Legal Menu Slot (Legal menu block)
+    description: Slot intended for legal links (e.g., privacy policy).
   social_media_slot:
     title: Social Media (UMD DS Social Icons block)
     description: Slot intended for social media links.

--- a/components/umd-libraries-footer/umd-libraries-footer.twig
+++ b/components/umd-libraries-footer/umd-libraries-footer.twig
@@ -433,6 +433,7 @@
   <div class="footer--sub c-bg-dark-secondary">
     <div
       class="footer--sub-content s-box-page-small-v s-box-page-default-h s-center">
+      {% block legal_menu_slot %}
       <ul>
         <li>
           <a href="/" class="ani-underline t-label c-underline-dark-primary">
@@ -450,6 +451,7 @@
           </a>
         </li>
       </ul>
+      {% endblock %}
       <div>
         <p class="t-label c-content-dark-primary">© 2025 UNIVERSITY OF MARYLAND</p>
       </div>

--- a/config/install/system.menu.legal-menu.yml
+++ b/config/install/system.menu.legal-menu.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: legal-menu
+label: 'Legal Menu'
+description: 'Bottom of footer menu with legal or administrative links'
+locked: false
+

--- a/templates/macros/menu-macros.twig
+++ b/templates/macros/menu-macros.twig
@@ -34,6 +34,26 @@
 
 {#
 /**
+ * Legal menu supports one level
+ */
+#}
+{% macro legal_menu_links(items, attributes, menu_level) %}
+  {% if items %}
+    <ul>
+      {% if menu_level == 0 %}
+        {% for item in items %}
+          <li>
+            {{ link(item.title, item.url, { 'class':['ani-underline', 't-label', 'c-underline-dark-primary'] }) }}
+          </li>
+        {% endfor %}
+      {% endif %}
+    </ul>
+  {% endif %}
+{% endmacro %}
+
+
+{#
+/**
  * Two levels level supported for main nav
  */
 #}

--- a/templates/navigation/menu--legal-menu.html.twig
+++ b/templates/navigation/menu--legal-menu.html.twig
@@ -1,0 +1,27 @@
+{#
+/**
+ * @file
+ * Theme override to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link URL, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import '@umdlib_umdds/macros/menu-macros.twig' as menus %}
+
+{#
+  We call a macro which calls itself to render the full tree.
+  @see https://twig.symfony.com/doc/3.x/tags/macro.html
+#}
+{{ menus.legal_menu_links(items, attributes, 0) }}


### PR DESCRIPTION
-Includes a new legal menu slot
-Includes default configuration for a legal menu
-Includes legal menu macro for generating markup

https://umd-dit.atlassian.net/browse/LIBWEB-6391